### PR TITLE
added subtitle preview under video

### DIFF
--- a/css/caption.css
+++ b/css/caption.css
@@ -1,0 +1,11 @@
+.caption-container {
+    text-align: center;
+    position:relative;
+    top: -5em;
+  }
+
+.caption {
+    display:inline-block;
+    color: white;
+    background-color: rgba(0, 0, 0, 0.85);
+}

--- a/js/add_caption.js
+++ b/js/add_caption.js
@@ -37,9 +37,14 @@ function is_complete(text) {
 
 
 function update_caption() {
-    var current_time = time_bar.getElementsByClassName("timecode text--noselect")[0];
+    var total_time = timestr2int(time_bar.getElementsByClassName("timecode text--noselect")[1].innerText);
+    var elabsed_bar = $(".ProgressBar-elapsed");
+    var elabsed_bar_width = parseFloat(elabsed_bar["0"].style.cssText.replace("width: ", "").replace("%;", "")); //percentage of total width
+    var current_time = total_time * elabsed_bar_width;
+
+
     var paragraphs = getParagraphs();
-    var index = get_index_of_paragraph(paragraphs, current_time.innerText);
+    var index = get_index_of_paragraph(paragraphs, current_time);
     parag_text = as_text(paragraphs[index]);
     if (!is_complete(parag_text) && index < paragraphs.length - 1) {
         next_parag_text = as_text(paragraphs[index + 1]);
@@ -51,12 +56,11 @@ function update_caption() {
 
     // function receives a time frame as string ("HH:MM:SS") , and returns a 
     // index of corresponding paragraph
-    function get_index_of_paragraph(paragraphs, timestr) {
-        var timeint = timestr2int(timestr);
+    function get_index_of_paragraph(paragraphs, current_time) {
         var paragraph_index = 0;
         var i;
         for (i = 0; i < paragraphs.length - 1; i++) {
-            var cond = timeint >= timestr2int(start_time(paragraphs[i + 1]));
+            var cond = current_time >= start_time(paragraphs[i + 1]);
             if (!cond) {
                 break;
             }
@@ -85,7 +89,7 @@ function update_caption() {
 
     // get start time of a paragraph 
     function start_time(parag_element) {
-        return parag_element.getElementsByClassName("exchange--timestamp-value").item(0).innerText;
+        return parseFloat(parag_element.dataset.exchangeFrom);
     }
 
     // get text content of a paragraph

--- a/js/add_caption.js
+++ b/js/add_caption.js
@@ -4,6 +4,7 @@ var time_bar = document.getElementById("waveform");
 var vid = document.getElementById("vjs_video_3_html5_api");
 
 vid.addEventListener("timeupdate", update_caption);
+window.addEventListener("keyup", update_caption);
 
 // if current time is close to the next paragraph by this margin
 // switch to the next paragraph

--- a/js/add_caption.js
+++ b/js/add_caption.js
@@ -1,6 +1,5 @@
 // Global declarations
 var eol = "###"
-var time_bar = document.getElementById("waveform");
 var vid = document.getElementById("vjs_video_3_html5_api");
 
 vid.addEventListener("timeupdate", update_caption);

--- a/js/add_caption.js
+++ b/js/add_caption.js
@@ -1,14 +1,12 @@
 // Global declarations
 var eol = "###"
 var time_bar = document.getElementById("waveform");
-// Options for the observer (which mutations to observe)
-// https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
-const config = { attributes: true, childList: true, subtree: true };
-// whenever the time in the timebar changes, the event is fired, and subtitles
-// are updated
-const observer = new MutationObserver(update_caption);
-observer.observe(time_bar, config);
+var vid = document.getElementById("vjs_video_3_html5_api");
+vid.ontimeupdate = update_caption;
 
+// if current time is close to the next paragraph by this margin
+// switch to the next paragraph
+var margin = 5
 // video window element
 var element = document.getElementById("vjs_video_3");
 
@@ -16,6 +14,7 @@ var element = document.getElementById("vjs_video_3");
 //this div will hold the captions
 var caption_container = document.createElement("div");
 caption_container.setAttribute("id", "caption_container");
+caption_container.setAttribute("dir", "rtl");
 caption_container.className = "caption-container";
 element.appendChild(caption_container);
 var caption = document.createElement("p");
@@ -41,8 +40,6 @@ function update_caption() {
     var elabsed_bar = $(".ProgressBar-elapsed");
     var elabsed_bar_width = parseFloat(elabsed_bar["0"].style.cssText.replace("width: ", "").replace("%;", "")); //percentage of total width
     var current_time = total_time * elabsed_bar_width;
-
-
     var paragraphs = getParagraphs();
     var index = get_index_of_paragraph(paragraphs, current_time);
     parag_text = as_text(paragraphs[index]);
@@ -51,50 +48,49 @@ function update_caption() {
         parag_text = parag_text.replace(eol, "").concat("<br>").concat(next_parag_text);
     }
     $(caption).html(parag_text.replace(eol, ""));
+}
 
-    // below are helper functions-------
+// helper functions
 
-    // function receives a time frame as string ("HH:MM:SS") , and returns a 
-    // index of corresponding paragraph
-    function get_index_of_paragraph(paragraphs, current_time) {
-        var paragraph_index = 0;
-        var i;
-        for (i = 0; i < paragraphs.length - 1; i++) {
-            var cond = current_time >= start_time(paragraphs[i + 1]);
-            if (!cond) {
-                break;
-            }
+// function receives a time frame as string ("HH:MM:SS") , and returns a 
+// index of corresponding paragraph
+function get_index_of_paragraph(paragraphs, current_time) {
+    var paragraph_index = 0;
+    var i;
+    for (i = 0; i < paragraphs.length - 1; i++) {
+        if (current_time+margin < start_time(paragraphs[i + 1])) {
+            break;
         }
-        paragraph_index = i;
-        if (paragraph_index > 0) {
-            previous_parag_text = as_text(paragraphs[paragraph_index - 1]);
-            if (!is_complete(previous_parag_text)) {
-                return paragraph_index - 1;
-            }
+    }
+    paragraph_index = i;
+    if (paragraph_index > 0) {
+        previous_parag_text = as_text(paragraphs[paragraph_index - 1]);
+        if (!is_complete(previous_parag_text)) {
+            return paragraph_index - 1;
         }
-        return paragraph_index;
     }
+    return paragraph_index;
+}
 
-    // convert time in string format ("HH:MM:SS") to seconds as total seconds (int)
-    function timestr2int(timestr) {
-        var segments = timestr.split(":");
-        var weight = 3600;
-        var result = 0;
-        for (segment of segments) {
-            result += parseInt(segment) * weight;
-            weight /= 60;
-        }
-        return result;
+// convert time in string format ("HH:MM:SS") to seconds as total seconds (int)
+function timestr2int(timestr) {
+    var segments = timestr.split(":");
+    var weight = 3600;
+    var result = 0;
+    for (segment of segments) {
+        result += parseInt(segment) * weight;
+        weight /= 60;
     }
+    return result;
+}
 
-    // get start time of a paragraph 
-    function start_time(parag_element) {
-        return parseFloat(parag_element.dataset.exchangeFrom);
-    }
+// get start time of a paragraph 
+function start_time(parag_element) {
+    return parseFloat(parag_element.dataset.exchangeFrom);
+}
 
-    // get text content of a paragraph
-    function as_text(parag_element) {
-        var content = parag_element.getElementsByClassName("exchange--content");
-        return $(content).text();
-    }
+// get text content of a paragraph
+function as_text(parag_element) {
+    var content = parag_element.getElementsByClassName("exchange--content");
+    return $(content).text();
 }

--- a/js/add_caption.js
+++ b/js/add_caption.js
@@ -1,0 +1,96 @@
+// Global declarations
+var eol = "###"
+var time_bar = document.getElementById("waveform");
+// Options for the observer (which mutations to observe)
+// https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
+const config = { attributes: true, childList: true, subtree: true };
+// whenever the time in the timebar changes, the event is fired, and subtitles
+// are updated
+const observer = new MutationObserver(update_caption);
+observer.observe(time_bar, config);
+
+// video window element
+var element = document.getElementById("vjs_video_3");
+
+// create a div, to be added as a child to video elemen
+//this div will hold the captions
+var caption_container = document.createElement("div");
+caption_container.setAttribute("id", "caption_container");
+caption_container.className = "caption-container";
+element.appendChild(caption_container);
+var caption = document.createElement("p");
+caption.setAttribute("id", "caption");
+caption.className = "caption";
+var text = document.createTextNode("");
+caption.appendChild(text);
+caption_container.appendChild(caption);
+
+
+function getParagraphs() {
+    var paragraphs = document.getElementsByClassName("exchange--speaker");
+    return paragraphs;
+}
+// check if paragraph is complete (no splitting)
+function is_complete(text) {
+    return !(text.length >= eol.length && text.substring(text.length - eol.length, text.length) == eol);
+}
+
+
+function update_caption() {
+    var current_time = time_bar.getElementsByClassName("timecode text--noselect")[0];
+    var paragraphs = getParagraphs();
+    var index = get_index_of_paragraph(paragraphs, current_time.innerText);
+    parag_text = as_text(paragraphs[index]);
+    if (!is_complete(parag_text) && index < paragraphs.length - 1) {
+        next_parag_text = as_text(paragraphs[index + 1]);
+        parag_text = parag_text.replace(eol, "").concat("<br>").concat(next_parag_text);
+    }
+    $(caption).html(parag_text.replace(eol, ""));
+
+    // below are helper functions-------
+
+    // function receives a time frame as string ("HH:MM:SS") , and returns a 
+    // index of corresponding paragraph
+    function get_index_of_paragraph(paragraphs, timestr) {
+        var timeint = timestr2int(timestr);
+        var paragraph_index = 0;
+        var i;
+        for (i = 0; i < paragraphs.length - 1; i++) {
+            var cond = timeint >= timestr2int(start_time(paragraphs[i + 1]));
+            if (!cond) {
+                break;
+            }
+        }
+        paragraph_index = i;
+        if (paragraph_index > 0) {
+            previous_parag_text = as_text(paragraphs[paragraph_index - 1]);
+            if (!is_complete(previous_parag_text)) {
+                return paragraph_index - 1;
+            }
+        }
+        return paragraph_index;
+    }
+
+    // convert time in string format ("HH:MM:SS") to seconds as total seconds (int)
+    function timestr2int(timestr) {
+        var segments = timestr.split(":");
+        var weight = 3600;
+        var result = 0;
+        for (segment of segments) {
+            result += parseInt(segment) * weight;
+            weight /= 60;
+        }
+        return result;
+    }
+
+    // get start time of a paragraph 
+    function start_time(parag_element) {
+        return parag_element.getElementsByClassName("exchange--timestamp-value").item(0).innerText;
+    }
+
+    // get text content of a paragraph
+    function as_text(parag_element) {
+        var content = parag_element.getElementsByClassName("exchange--content");
+        return $(content).text();
+    }
+}

--- a/js/add_caption.js
+++ b/js/add_caption.js
@@ -2,7 +2,8 @@
 var eol = "###"
 var time_bar = document.getElementById("waveform");
 var vid = document.getElementById("vjs_video_3_html5_api");
-vid.ontimeupdate = update_caption;
+
+vid.addEventListener("timeupdate", update_caption);
 
 // if current time is close to the next paragraph by this margin
 // switch to the next paragraph
@@ -36,10 +37,7 @@ function is_complete(text) {
 
 
 function update_caption() {
-    var total_time = timestr2int(time_bar.getElementsByClassName("timecode text--noselect")[1].innerText);
-    var elabsed_bar = $(".ProgressBar-elapsed");
-    var elabsed_bar_width = parseFloat(elabsed_bar["0"].style.cssText.replace("width: ", "").replace("%;", "")); //percentage of total width
-    var current_time = total_time * elabsed_bar_width;
+    var current_time = vid.currentTime*100.0;//total_time * elabsed_bar_width;
     var paragraphs = getParagraphs();
     var index = get_index_of_paragraph(paragraphs, current_time);
     parag_text = as_text(paragraphs[index]);

--- a/js/count_characters.js
+++ b/js/count_characters.js
@@ -1,6 +1,6 @@
 // Global declarations
+var eol = "###"
 var time_bar = document.getElementById("waveform");
-
 // Options for the observer (which mutations to observe)
 // https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
 const config = { attributes: true, childList: true, subtree: true };
@@ -60,8 +60,8 @@ function addCount(obj) {
 
     var count = text.length;
 
-    if(text.length >= 3 && text.substring(text.length-3, text.length) == "###") {
-        count -= 3;
+    if(!is_complete(text)) {
+        count -= eol.length;
     }
 
     $(extra).append("<span class=\"characters-count\">" + count.toString() + "</span>");
@@ -71,6 +71,10 @@ function getParagraphs() {
     var paragraphs = document.getElementsByClassName("exchange--speaker");
     return paragraphs;
 }
+// check if paragraph is complete (no splitting)
+function is_complete(text){ 
+    return !(text.length >= eol.length && text.substring(text.length-eol.length, text.length) == eol);
+} 
 
 
 
@@ -81,7 +85,7 @@ function update_subtitle(){
     parag_text = as_text(paragraphs[index]);
     if (!is_complete(parag_text)){
         next_parag_text = as_text(paragraphs[index+1]);
-        parag_text = parag_text.replace("###", "").concat("<br>").concat(next_parag_text);
+        parag_text = parag_text.replace(eol, "").concat("<br>").concat(next_parag_text);
     }
     $(caption).html(parag_text);
 
@@ -122,15 +126,8 @@ function update_subtitle(){
     
     // get start time of a paragraph 
     function  start_time(parag_element){
-        parag_element;
         return parag_element.getElementsByClassName("exchange--timestamp-value").item(0).innerText;
-    }
-
-    // check if paragraph is complete (no splitting)
-    function is_complete(text, eol="###"){
-        var val = !(text.length >= eol.length && text.substring(text.length-eol.length, text.length) == eol); 
-        return !(text.length >= eol.length && text.substring(text.length-eol.length, text.length) == eol);
-    }  
+    } 
     
     // get text content of a paragraph
     function as_text(parag_element){

--- a/js/count_characters.js
+++ b/js/count_characters.js
@@ -4,16 +4,20 @@ var time_bar = document.getElementById("waveform");
 // Options for the observer (which mutations to observe)
 // https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
 const config = { attributes: true, childList: true, subtree: true };
+// whenever the time in the timebar changes, the event is fired, and subtitles
+// are updated
 const observer = new MutationObserver(update_subtitle);
 observer.observe(time_bar, config);
 
+// video window element
 var element = document.getElementById("vjs_video_3");
+
+// create a div, to be added as a child to video elemen
+//this div will hold the captions
 var caption_container = document.createElement("div");
 caption_container.setAttribute("id", "caption_container");
 caption_container.style.cssText = "text-align: center; position:relative; top: -5em;";
 element.appendChild(caption_container);
-
-
 var caption = document.createElement("p");
 caption.setAttribute("id", "caption");
 caption.style.cssText = "display:inline-block; color: white; background-color: rgba(0, 0, 0, 0.85);";
@@ -79,17 +83,17 @@ function update_subtitle(){
         next_parag_text = as_text(paragraphs[index+1]);
         parag_text = parag_text.replace("###", "").concat("<br>").concat(next_parag_text);
     }
-
     $(caption).html(parag_text);
 
-    
+    // below are helper functions-------
+
     // function receives a time frame as string ("HH:MM:SS") , and returns a 
-    // paragraph object
+    // index of corresponding paragraph
     function get_index_of_paragraph(paragraphs, timestr){
         var timeint = timestr2int(timestr);
         var paragraph_index = 0;
         var i;
-        for (i = 0; i< paragraphs.length; i++){
+        for (i = 0; i< paragraphs.length-1; i++){
             var cond = timeint >= timestr2int(start_time(paragraphs[i+1])) ;
             if (!cond){
                 break;}
@@ -104,7 +108,7 @@ function update_subtitle(){
         return paragraph_index;
     }
     
-    // convert time in string format ("HH:MM:SS") to seconds as int (65)
+    // convert time in string format ("HH:MM:SS") to seconds as total seconds (int)
     function timestr2int(timestr){
         var segments = timestr.split(":");
         var weight = 3600;
@@ -115,16 +119,20 @@ function update_subtitle(){
         } 
         return result;
     }
-     
+    
+    // get start time of a paragraph 
     function  start_time(parag_element){
         parag_element;
         return parag_element.getElementsByClassName("exchange--timestamp-value").item(0).innerText;
     }
+
+    // check if paragraph is complete (no splitting)
     function is_complete(text, eol="###"){
         var val = !(text.length >= eol.length && text.substring(text.length-eol.length, text.length) == eol); 
         return !(text.length >= eol.length && text.substring(text.length-eol.length, text.length) == eol);
     }  
     
+    // get text content of a paragraph
     function as_text(parag_element){
         var content = parag_element.getElementsByClassName("exchange--content");
         return $(content).text();

--- a/js/count_characters.js
+++ b/js/count_characters.js
@@ -1,23 +1,21 @@
-//var time_bar = document.getElementById("waveform");
-//var current_time = time_bar.getElementsByClassName("timecode text--noselect")[0]
-
-
-// events for testing
-
-$(document).ready(window.setInterval(update_subtitle, 200)); 
 // Global declarations
 var time_bar = document.getElementById("waveform");
+
+// Options for the observer (which mutations to observe)
+// https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
+const config = { attributes: true, childList: true, subtree: true };
+const observer = new MutationObserver(update_subtitle);
+observer.observe(time_bar, config);
+
+
 var caption = document.createElement("p");
-//var t = window.setTimeout(function(){ window.clearInterval(t);}, 5000);
-//window.setInterval(get_script, 100);
-
-
 caption.setAttribute("id", "caption");
+caption.style.cssText = "text-align: center; color: white; background-color: black;";
 var text = document.createTextNode("intital");
 caption.appendChild(text);
 var element = document.getElementById("vjs_video_3");
 element.appendChild(caption);
-//_________END my chnages________________
+
 
 
 
@@ -120,7 +118,8 @@ function update_subtitle(){
     };
 
     function updateCaption(val){  
-        caption.textContent = val;
+        //caption.textContent = val;
+        $(caption).html(val);
         };
 };
 
@@ -157,7 +156,7 @@ class Paragraph {
         var content = parag_element.getElementsByClassName("exchange--content");
         text = $(content).text();
         if (!this._is_complete(text)){
-            return text.replace(this.eol, "").concat("\n").concat(this._extract_text(parag_element.nextSibling));
+            return text.replace(this.eol, "").concat("<br>").concat(this._extract_text(parag_element.nextSibling));
         }
          
         return text;

--- a/js/count_characters.js
+++ b/js/count_characters.js
@@ -7,14 +7,19 @@ const config = { attributes: true, childList: true, subtree: true };
 const observer = new MutationObserver(update_subtitle);
 observer.observe(time_bar, config);
 
+var element = document.getElementById("vjs_video_3");
+var caption_container = document.createElement("div");
+caption_container.setAttribute("id", "caption_container");
+caption_container.style.cssText = "text-align: center; position:relative; top: -5em;";
+element.appendChild(caption_container);
+
 
 var caption = document.createElement("p");
 caption.setAttribute("id", "caption");
-caption.style.cssText = "text-align: center; color: white; background-color: black;";
-var text = document.createTextNode("intital");
+caption.style.cssText = "display:inline-block; color: white; background-color: rgba(0, 0, 0, 0.85);";
+var text = document.createTextNode("");
 caption.appendChild(text);
-var element = document.getElementById("vjs_video_3");
-element.appendChild(caption);
+caption_container.appendChild(caption);
 
 
 
@@ -94,7 +99,7 @@ function update_subtitle(){
         var parag = new Paragraph(paragraphs[0]);
         
 
-        while (!(timeint < timestr2int(parag.end_time()))){
+        while (timeint >= timestr2int(parag.end_time())){
             parag = new Paragraph(parag.nextParagraph);
         }
         updateCaption(parag.as_text());
@@ -137,7 +142,11 @@ class Paragraph {
         if (!this.nextParagraph){
             this.as_text(); //to update nextParag var 
         }   
-        this._end_time = this.nextParagraph.getElementsByClassName("exchange--timestamp-value").item(0).innerText;
+        try{
+        this._end_time = this.nextParagraph.getElementsByClassName("exchange--timestamp-value").item(0).innerText;}
+        catch{
+            debugger;
+        }
         return this._end_time;
     }
 
@@ -156,7 +165,12 @@ class Paragraph {
         var content = parag_element.getElementsByClassName("exchange--content");
         text = $(content).text();
         if (!this._is_complete(text)){
-            return text.replace(this.eol, "").concat("<br>").concat(this._extract_text(parag_element.nextSibling));
+            try{
+            return text.replace(this.eol, "").concat("<br>").concat(this._extract_text(parag_element.nextSibling));}
+            catch{
+            return text.replace(this.eol, "");
+            debugger; 
+            }
         }
          
         return text;

--- a/js/count_characters.js
+++ b/js/count_characters.js
@@ -3,8 +3,8 @@
 
 
 // events for testing
-window.setInterval(update_subtitle, 5000);
 
+$(document).ready(window.setInterval(update_subtitle, 200)); 
 // Global declarations
 var time_bar = document.getElementById("waveform");
 var caption = document.createElement("p");
@@ -94,10 +94,12 @@ function update_subtitle(){
         var timeint = timestr2int(timestr);
         var paragraphs =  getParagraphs();
         var parag = new Paragraph(paragraphs[0]);
-        var stime = parag.start_time();
-        var etime = parag.end_time();
-        var text = parag.as_text();
-        debugger;
+        
+
+        while (!(timeint < timestr2int(parag.end_time()))){
+            parag = new Paragraph(parag.nextParagraph);
+        }
+        updateCaption(parag.as_text());
 
 
         
@@ -155,7 +157,7 @@ class Paragraph {
         var content = parag_element.getElementsByClassName("exchange--content");
         text = $(content).text();
         if (!this._is_complete(text)){
-            return text.replace(this.eol, "").concat(" ").concat(this._extract_text(parag_element.nextSibling));
+            return text.replace(this.eol, "").concat("\n").concat(this._extract_text(parag_element.nextSibling));
         }
          
         return text;

--- a/js/count_characters.js
+++ b/js/count_characters.js
@@ -66,49 +66,44 @@ function addCount(obj) {
 function getParagraphs() {
     var paragraphs = document.getElementsByClassName("exchange--speaker");
     return paragraphs;
-};
-
-// my changes_________________________-
-
-
-//make a class for paragraph
-
-function get_script(){
-var current_time = time_bar.getElementsByClassName("timecode text--noselect")[0];
-updateCaption(current_time.innerText); 
 }
-
-
 
 
 
 function update_subtitle(){
     var current_time = time_bar.getElementsByClassName("timecode text--noselect")[0];
-    get_index_of_paragraph(current_time.innerText);  
+    var paragraphs =  getParagraphs();
+    var index = get_index_of_paragraph(paragraphs, current_time.innerText);
+    parag_text = as_text(paragraphs[index]);
+    if (!is_complete(parag_text)){
+        next_parag_text = as_text(paragraphs[index+1]);
+        parag_text = parag_text.replace("###", "").concat("<br>").concat(next_parag_text);
+    }
 
+    $(caption).html(parag_text);
 
-        
- 
-
+    
     // function receives a time frame as string ("HH:MM:SS") , and returns a 
     // paragraph object
-    function get_index_of_paragraph(timestr){
-        
+    function get_index_of_paragraph(paragraphs, timestr){
         var timeint = timestr2int(timestr);
-        var paragraphs =  getParagraphs();
-        var parag = new Paragraph(paragraphs[0]);
-        
-
-        while (timeint >= timestr2int(parag.end_time())){
-            parag = new Paragraph(parag.nextParagraph);
+        var paragraph_index = 0;
+        var i;
+        for (i = 0; i< paragraphs.length; i++){
+            var cond = timeint >= timestr2int(start_time(paragraphs[i+1])) ;
+            if (!cond){
+                break;}
         }
-        updateCaption(parag.as_text());
-
-
-        
-
-
-
+        paragraph_index = i;
+        if (paragraph_index>0){
+            previous_parag_text = as_text(paragraphs[paragraph_index-1]);
+            if(!is_complete(previous_parag_text)){
+                return paragraph_index - 1; 
+            }
+        }
+        return paragraph_index;
+    }
+    
     // convert time in string format ("HH:MM:SS") to seconds as int (65)
     function timestr2int(timestr){
         var segments = timestr.split(":");
@@ -119,66 +114,19 @@ function update_subtitle(){
             weight /= 60;
         } 
         return result;
-    };
-    };
-
-    function updateCaption(val){  
-        //caption.textContent = val;
-        $(caption).html(val);
-        };
-};
-
-
-
-// Paragraphs class
-class Paragraph {
-    constructor(parag_element, eol="###") {
-      this.parag_element = parag_element;
-      this.eol = eol;
-      this.nextParagraph = false;
     }
-
-    end_time(){
-        if (!this.nextParagraph){
-            this.as_text(); //to update nextParag var 
-        }   
-        try{
-        this._end_time = this.nextParagraph.getElementsByClassName("exchange--timestamp-value").item(0).innerText;}
-        catch{
-            debugger;
-        }
-        return this._end_time;
+     
+    function  start_time(parag_element){
+        parag_element;
+        return parag_element.getElementsByClassName("exchange--timestamp-value").item(0).innerText;
     }
-
-    as_text(){
-        return this._extract_text(this.parag_element);
-    }
-
-    start_time(){
-        this._start_time = this.parag_element.getElementsByClassName("exchange--timestamp-value").item(0).innerText;
-        return this._start_time;
-    }
-
-  
-    _extract_text(parag_element){
-        this.nextParagraph = parag_element.nextSibling;
-        var content = parag_element.getElementsByClassName("exchange--content");
-        text = $(content).text();
-        if (!this._is_complete(text)){
-            try{
-            return text.replace(this.eol, "").concat("<br>").concat(this._extract_text(parag_element.nextSibling));}
-            catch{
-            return text.replace(this.eol, "");
-            debugger; 
-            }
-        }
-         
-        return text;
-    }
+    function is_complete(text, eol="###"){
+        var val = !(text.length >= eol.length && text.substring(text.length-eol.length, text.length) == eol); 
+        return !(text.length >= eol.length && text.substring(text.length-eol.length, text.length) == eol);
+    }  
     
-    _is_complete(text){
-        return !(text.length >= this.eol.length && text.substring(text.length-this.eol.length, text.length) == this.eol);
-      }  
+    function as_text(parag_element){
+        var content = parag_element.getElementsByClassName("exchange--content");
+        return $(content).text();
+    }    
 }
-
-

--- a/js/count_characters.js
+++ b/js/count_characters.js
@@ -1,32 +1,4 @@
-// Global declarations
 var eol = "###"
-var time_bar = document.getElementById("waveform");
-// Options for the observer (which mutations to observe)
-// https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
-const config = { attributes: true, childList: true, subtree: true };
-// whenever the time in the timebar changes, the event is fired, and subtitles
-// are updated
-const observer = new MutationObserver(update_subtitle);
-observer.observe(time_bar, config);
-
-// video window element
-var element = document.getElementById("vjs_video_3");
-
-// create a div, to be added as a child to video elemen
-//this div will hold the captions
-var caption_container = document.createElement("div");
-caption_container.setAttribute("id", "caption_container");
-caption_container.style.cssText = "text-align: center; position:relative; top: -5em;";
-element.appendChild(caption_container);
-var caption = document.createElement("p");
-caption.setAttribute("id", "caption");
-caption.style.cssText = "display:inline-block; color: white; background-color: rgba(0, 0, 0, 0.85);";
-var text = document.createTextNode("");
-caption.appendChild(text);
-caption_container.appendChild(caption);
-
-
-
 
 window.addEventListener("load", function () {
     addCounts();
@@ -74,65 +46,4 @@ function getParagraphs() {
 // check if paragraph is complete (no splitting)
 function is_complete(text) {
     return !(text.length >= eol.length && text.substring(text.length - eol.length, text.length) == eol);
-}
-
-
-
-function update_subtitle() {
-    var current_time = time_bar.getElementsByClassName("timecode text--noselect")[0];
-    var paragraphs = getParagraphs();
-    var index = get_index_of_paragraph(paragraphs, current_time.innerText);
-    parag_text = as_text(paragraphs[index]);
-    if (!is_complete(parag_text) && index < paragraphs.length - 1) {
-        next_parag_text = as_text(paragraphs[index + 1]);
-        parag_text = parag_text.replace(eol, "").concat("<br>").concat(next_parag_text);
-    }
-    $(caption).html(parag_text.replace(eol, ""));
-
-    // below are helper functions-------
-
-    // function receives a time frame as string ("HH:MM:SS") , and returns a 
-    // index of corresponding paragraph
-    function get_index_of_paragraph(paragraphs, timestr) {
-        var timeint = timestr2int(timestr);
-        var paragraph_index = 0;
-        var i;
-        for (i = 0; i < paragraphs.length - 1; i++) {
-            var cond = timeint >= timestr2int(start_time(paragraphs[i + 1]));
-            if (!cond) {
-                break;
-            }
-        }
-        paragraph_index = i;
-        if (paragraph_index > 0) {
-            previous_parag_text = as_text(paragraphs[paragraph_index - 1]);
-            if (!is_complete(previous_parag_text)) {
-                return paragraph_index - 1;
-            }
-        }
-        return paragraph_index;
-    }
-
-    // convert time in string format ("HH:MM:SS") to seconds as total seconds (int)
-    function timestr2int(timestr) {
-        var segments = timestr.split(":");
-        var weight = 3600;
-        var result = 0;
-        for (segment of segments) {
-            result += parseInt(segment) * weight;
-            weight /= 60;
-        }
-        return result;
-    }
-
-    // get start time of a paragraph 
-    function start_time(parag_element) {
-        return parag_element.getElementsByClassName("exchange--timestamp-value").item(0).innerText;
-    }
-
-    // get text content of a paragraph
-    function as_text(parag_element) {
-        var content = parag_element.getElementsByClassName("exchange--content");
-        return $(content).text();
-    }
 }

--- a/js/count_characters.js
+++ b/js/count_characters.js
@@ -1,3 +1,26 @@
+//var time_bar = document.getElementById("waveform");
+//var current_time = time_bar.getElementsByClassName("timecode text--noselect")[0]
+
+
+// events for testing
+window.setInterval(update_subtitle, 5000);
+
+// Global declarations
+var time_bar = document.getElementById("waveform");
+var caption = document.createElement("p");
+//var t = window.setTimeout(function(){ window.clearInterval(t);}, 5000);
+//window.setInterval(get_script, 100);
+
+
+caption.setAttribute("id", "caption");
+var text = document.createTextNode("intital");
+caption.appendChild(text);
+var element = document.getElementById("vjs_video_3");
+element.appendChild(caption);
+//_________END my chnages________________
+
+
+
 window.addEventListener("load", function() {
     addCounts();
 });
@@ -24,6 +47,8 @@ function addCount(obj) {
     extra = obj.getElementsByClassName("exchange--extra");
 
     var text = $(content).text();
+
+
     text = text.match(ACCEPTED_CHARS_REGEX).join("");
 
     var count = text.length;
@@ -39,3 +64,56 @@ function getParagraphs() {
     var paragraphs = document.getElementsByClassName("exchange--speaker");
     return paragraphs;
 };
+
+// my changes_________________________-
+
+
+//make a class for paragraph
+
+function get_script(){
+var current_time = time_bar.getElementsByClassName("timecode text--noselect")[0];
+updateCaption(current_time.innerText); 
+}
+
+
+
+
+
+function update_subtitle(){
+    var current_time = time_bar.getElementsByClassName("timecode text--noselect")[0];
+    get_index_of_paragraph(current_time.innerText);  
+
+
+        
+ 
+
+    // function receives a time frame as string ("HH:MM:SS") , and returns the 
+    // corresponding paragraph
+    function get_index_of_paragraph(timestr){
+        var timeint = timestr2int(timestr);
+        var paragraphs =  getParagraphs();
+        var parag = paragraphs[0];
+        updateCaption(parag.textContent);
+
+
+    // convert time in string format ("HH:MM:SS") to seconds in int (65)
+    function timestr2int(timestr){
+        var segments = timestr.split(":");
+        var weight = 3600;
+        var result = 0;
+        for (segment of segments) {
+            result += parseInt(segment)*weight;
+            weight /= 60;
+        } 
+        return result;
+    };
+    };
+
+    function updateCaption(val){  
+        caption.textContent = val;
+        };
+};
+
+
+
+

--- a/js/count_characters.js
+++ b/js/count_characters.js
@@ -28,23 +28,23 @@ caption_container.appendChild(caption);
 
 
 
-window.addEventListener("load", function() {
+window.addEventListener("load", function () {
     addCounts();
 });
 
-window.addEventListener("keyup", function() {
+window.addEventListener("keyup", function () {
     addCounts();
 });
 
-window.addEventListener('scroll', function() {
+window.addEventListener('scroll', function () {
     addCounts();
-    setTimeout(function(){ addCounts() }, 200);
+    setTimeout(function () { addCounts() }, 200);
 });
 
 function addCounts() {
     $(".characters-count").remove();
     var paragraphs = getParagraphs();
-    for(var i = 0; i < paragraphs.length; ++i) {
+    for (var i = 0; i < paragraphs.length; ++i) {
         addCount(paragraphs[i]);
     }
 };
@@ -60,7 +60,7 @@ function addCount(obj) {
 
     var count = text.length;
 
-    if(!is_complete(text)) {
+    if (!is_complete(text)) {
         count -= eol.length;
     }
 
@@ -72,66 +72,67 @@ function getParagraphs() {
     return paragraphs;
 }
 // check if paragraph is complete (no splitting)
-function is_complete(text){ 
-    return !(text.length >= eol.length && text.substring(text.length-eol.length, text.length) == eol);
-} 
+function is_complete(text) {
+    return !(text.length >= eol.length && text.substring(text.length - eol.length, text.length) == eol);
+}
 
 
 
-function update_subtitle(){
+function update_subtitle() {
     var current_time = time_bar.getElementsByClassName("timecode text--noselect")[0];
-    var paragraphs =  getParagraphs();
+    var paragraphs = getParagraphs();
     var index = get_index_of_paragraph(paragraphs, current_time.innerText);
     parag_text = as_text(paragraphs[index]);
-    if (!is_complete(parag_text)){
-        next_parag_text = as_text(paragraphs[index+1]);
+    if (!is_complete(parag_text) && index < paragraphs.length - 1) {
+        next_parag_text = as_text(paragraphs[index + 1]);
         parag_text = parag_text.replace(eol, "").concat("<br>").concat(next_parag_text);
     }
-    $(caption).html(parag_text);
+    $(caption).html(parag_text.replace(eol, ""));
 
     // below are helper functions-------
 
     // function receives a time frame as string ("HH:MM:SS") , and returns a 
     // index of corresponding paragraph
-    function get_index_of_paragraph(paragraphs, timestr){
+    function get_index_of_paragraph(paragraphs, timestr) {
         var timeint = timestr2int(timestr);
         var paragraph_index = 0;
         var i;
-        for (i = 0; i< paragraphs.length-1; i++){
-            var cond = timeint >= timestr2int(start_time(paragraphs[i+1])) ;
-            if (!cond){
-                break;}
+        for (i = 0; i < paragraphs.length - 1; i++) {
+            var cond = timeint >= timestr2int(start_time(paragraphs[i + 1]));
+            if (!cond) {
+                break;
+            }
         }
         paragraph_index = i;
-        if (paragraph_index>0){
-            previous_parag_text = as_text(paragraphs[paragraph_index-1]);
-            if(!is_complete(previous_parag_text)){
-                return paragraph_index - 1; 
+        if (paragraph_index > 0) {
+            previous_parag_text = as_text(paragraphs[paragraph_index - 1]);
+            if (!is_complete(previous_parag_text)) {
+                return paragraph_index - 1;
             }
         }
         return paragraph_index;
     }
-    
+
     // convert time in string format ("HH:MM:SS") to seconds as total seconds (int)
-    function timestr2int(timestr){
+    function timestr2int(timestr) {
         var segments = timestr.split(":");
         var weight = 3600;
         var result = 0;
         for (segment of segments) {
-            result += parseInt(segment)*weight;
+            result += parseInt(segment) * weight;
             weight /= 60;
-        } 
+        }
         return result;
     }
-    
+
     // get start time of a paragraph 
-    function  start_time(parag_element){
+    function start_time(parag_element) {
         return parag_element.getElementsByClassName("exchange--timestamp-value").item(0).innerText;
-    } 
-    
+    }
+
     // get text content of a paragraph
-    function as_text(parag_element){
+    function as_text(parag_element) {
         var content = parag_element.getElementsByClassName("exchange--content");
         return $(content).text();
-    }    
+    }
 }

--- a/js/count_characters.js
+++ b/js/count_characters.js
@@ -87,16 +87,24 @@ function update_subtitle(){
         
  
 
-    // function receives a time frame as string ("HH:MM:SS") , and returns the 
-    // corresponding paragraph
+    // function receives a time frame as string ("HH:MM:SS") , and returns a 
+    // paragraph object
     function get_index_of_paragraph(timestr){
+        
         var timeint = timestr2int(timestr);
         var paragraphs =  getParagraphs();
-        var parag = paragraphs[0];
-        updateCaption(parag.textContent);
+        var parag = new Paragraph(paragraphs[0]);
+        var stime = parag.start_time();
+        var etime = parag.end_time();
+        var text = parag.as_text();
+        debugger;
 
 
-    // convert time in string format ("HH:MM:SS") to seconds in int (65)
+        
+
+
+
+    // convert time in string format ("HH:MM:SS") to seconds as int (65)
     function timestr2int(timestr){
         var segments = timestr.split(":");
         var weight = 3600;
@@ -115,5 +123,47 @@ function update_subtitle(){
 };
 
 
+
+// Paragraphs class
+class Paragraph {
+    constructor(parag_element, eol="###") {
+      this.parag_element = parag_element;
+      this.eol = eol;
+      this.nextParagraph = false;
+    }
+
+    end_time(){
+        if (!this.nextParagraph){
+            this.as_text(); //to update nextParag var 
+        }   
+        this._end_time = this.nextParagraph.getElementsByClassName("exchange--timestamp-value").item(0).innerText;
+        return this._end_time;
+    }
+
+    as_text(){
+        return this._extract_text(this.parag_element);
+    }
+
+    start_time(){
+        this._start_time = this.parag_element.getElementsByClassName("exchange--timestamp-value").item(0).innerText;
+        return this._start_time;
+    }
+
+  
+    _extract_text(parag_element){
+        this.nextParagraph = parag_element.nextSibling;
+        var content = parag_element.getElementsByClassName("exchange--content");
+        text = $(content).text();
+        if (!this._is_complete(text)){
+            return text.replace(this.eol, "").concat(" ").concat(this._extract_text(parag_element.nextSibling));
+        }
+         
+        return text;
+    }
+    
+    _is_complete(text){
+        return !(text.length >= this.eol.length && text.substring(text.length-this.eol.length, text.length) == this.eol);
+      }  
+}
 
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,13 +2,13 @@
   "manifest_version": 2,
 
   "name": "sonix.ai assistant",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "homepage_url": "https://github.com/IbraheemTuffaha/sonix-ai",
   "description": "An extension for sonix.ai to add more options related to fonts and managing characters in edit environment.",
   "permissions": ["https://my.sonix.ai/recordings/*"],
   "content_scripts": [{
-    "css": ["css/count_characters.css", "css/change_font.css"],
-    "js": ["js/jquery-3.4.1.min.js", "js/count_characters.js", "js/constants.js", "js/change_font.js"],
+    "css": ["css/count_characters.css", "css/change_font.css", "css/caption.css"],
+    "js": ["js/jquery-3.4.1.min.js", "js/count_characters.js", "js/constants.js", "js/change_font.js", "js/add_caption.js"],
     "matches": ["https://my.sonix.ai/recordings/*"]
   }],
 


### PR DESCRIPTION
Added a function ```update_subtitle``` which gets executed whenever a change is occurred to  the time shown at left of the video time bar.

At every call, the ```update_subtitle``` function:
- reads the time.
- converts it to seconds.
- finds the matching paragraph.
- gets the text inside it, finds out if it ends with "###", if so it appends the next paragraph, it also
checks the previous paragraph to see if the current paragraph should be appended to the one before.
- and finally, it updates a paragraph element accordingly. The paragraph element is add under the video and shows the subtitle.

#### Weaknesses:
- Since the Sonix interface exposes time in seconds only (not milliseconds), the subtitle sometimes appears to be out of sync, the offset is small and I think can be neglected.

#### Assumptions:
- There are no consecutive paragraphs ending with "###".
