### PR TITLE
Fix: Append all pragraphs ending with ###, not just the next paragraph

### DIFF
--- a/js/add_caption.js
+++ b/js/add_caption.js
@@ -112,6 +112,5 @@ function is_match(current_time, paragraphs, index){
         var words = paragraphs[index].getElementsByClassName("word");
         etime = parseFloat(words[words.length-1].dataset.to);        
     }
-    debugger;
     return (current_time >= stime && current_time < etime);
 }

--- a/js/add_caption.js
+++ b/js/add_caption.js
@@ -26,22 +26,15 @@ caption.appendChild(text);
 caption_container.appendChild(caption);
 
 
-function getParagraphs() {
-    var paragraphs = document.getElementsByClassName("exchange--speaker");
-    return paragraphs;
-}
-// check if paragraph is complete (no splitting)
-function is_complete(text) {
-    return !(text.length >= eol.length && text.substring(text.length - eol.length, text.length) == eol);
-}
-
-
 function update_caption() {
-    var current_time = vid.currentTime*100.0;//total_time * elabsed_bar_width;
+    var current_time = vid.currentTime*100.0 + margin;//total_time * elabsed_bar_width;
     var paragraphs = getParagraphs();
     var index = get_index_of_paragraph(paragraphs, current_time);
+    if(index==-1){return 0;}//do not do anything if no caption is found
     parag_text = as_text(paragraphs[index]);
-    if (!is_complete(parag_text) && index < paragraphs.length - 1) {
+
+    for(index; index < paragraphs.length - 1; index++){
+        if (is_parag_complete(paragraphs[index])){break;}
         next_parag_text = as_text(paragraphs[index + 1]);
         parag_text = parag_text.replace(eol, "").concat("<br>").concat(next_parag_text);
     }
@@ -49,25 +42,33 @@ function update_caption() {
 }
 
 // helper functions
+function getParagraphs() {
+    var paragraphs = document.getElementsByClassName("exchange--speaker");
+    return paragraphs;
+}
+// check if paragraph is complete (no splitting)
+function is_parag_complete(parag_element) {
+    var text = as_text(parag_element);
+    return !(text.length >= eol.length && text.substring(text.length - eol.length, text.length) == eol);
+}
 
 // function receives a time frame as string ("HH:MM:SS") , and returns a 
 // index of corresponding paragraph
 function get_index_of_paragraph(paragraphs, current_time) {
-    var paragraph_index = 0;
-    var i;
-    for (i = 0; i < paragraphs.length - 1; i++) {
-        if (current_time+margin < start_time(paragraphs[i + 1])) {
+    var index = 0;
+    var found = false;
+    for (index = 0; index < paragraphs.length - 1; index++) {
+        if (current_time >= start_time(paragraphs[index]) && current_time < start_time(paragraphs[index + 1])) {
+            found = true;
             break;
         }
     }
-    paragraph_index = i;
-    if (paragraph_index > 0) {
-        previous_parag_text = as_text(paragraphs[paragraph_index - 1]);
-        if (!is_complete(previous_parag_text)) {
-            return paragraph_index - 1;
-        }
+    //if no matching caption is found, return -1 indicating not found
+    if (!found){return -1;}
+    for (index; index > 0; index--){
+        if (is_parag_complete(paragraphs[index-1])){break;}
     }
-    return paragraph_index;
+    return index;
 }
 
 // get start time of a paragraph 

--- a/js/add_caption.js
+++ b/js/add_caption.js
@@ -42,7 +42,7 @@ function update_caption() {
         next_parag_text = as_text(paragraphs[index + 1]);
         parag_text = parag_text.replace(eol, "").concat("<br>").concat(next_parag_text);
     }
-    $(caption).html(parag_text.replace(eol, ""));
+    $(caption).html(parag_text);
 }
 
 // helper functions

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
 
   "name": "sonix.ai assistant",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "homepage_url": "https://github.com/IbraheemTuffaha/sonix-ai",
   "description": "An extension for sonix.ai to add more options related to fonts and managing characters in edit environment.",
   "permissions": ["https://my.sonix.ai/recordings/*"],


### PR DESCRIPTION
This PR fixes the following:
- Appending all paragraphs ending with ###. Added a loop to keep appending those paragraphs.
It checks for paragraphs that are before and after the current one.

- Added end time check. now the caption is controlled by the start and end time of the current paragraph. (previously it used to look for start time of current paragraph and the start time of the next paragraph). In the case of incomplete paragraph (ending with ###), it takes the correct time (uses the start/end time of the next or previous paragraph..).

- if user adds ### incorrectly (ex. ### followed by  a dot), the ### is not auto removed. So the user see what he does exactly even if it's incorrect.