### PR TITLE
caption update is called only when video is playing

### DIFF
--- a/js/add_caption.js
+++ b/js/add_caption.js
@@ -2,8 +2,13 @@
 var eol = "###"
 var vid = document.getElementById("vjs_video_3_html5_api");
 
-vid.addEventListener("timeupdate", update_caption);
-window.addEventListener("keyup", update_caption);
+vid.onplay = function() {
+    vid.addEventListener("timeupdate", update_caption);
+};
+
+vid.onpause = function() {
+    vid.removeEventListener("timeupdate", update_caption);
+};
 
 // if current time is close to the next paragraph by this margin
 // switch to the next paragraph

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
 
   "name": "sonix.ai assistant",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "homepage_url": "https://github.com/IbraheemTuffaha/sonix-ai",
   "description": "An extension for sonix.ai to add more options related to fonts and managing characters in edit environment.",
   "permissions": [],


### PR DESCRIPTION
The following changes are made:
- The ```timeupdate``` EventListener is now only activated (added) when the video is playing. If it is paused, the EventListener is removed again.
- The ```keyup``` event is not used anymore.
