### PR TITLE
Reduce load addcount

### DIFF
--- a/js/count_characters.js
+++ b/js/count_characters.js
@@ -1,16 +1,10 @@
 var eol = "###"
 
-window.addEventListener("load", function () {
-    addCounts();
-});
+var vid = document.getElementById("vjs_video_3_html5_api");
 
-window.addEventListener("keyup", function () {
+vid.addEventListener("play", function () {
     addCounts();
-});
-
-window.addEventListener('scroll', function () {
-    addCounts();
-    setTimeout(function () { addCounts() }, 200);
+    window.addEventListener("keyup", clearCounts);
 });
 
 function addCounts() {
@@ -46,4 +40,13 @@ function getParagraphs() {
 // check if paragraph is complete (no splitting)
 function is_complete(text) {
     return !(text.length >= eol.length && text.substring(text.length - eol.length, text.length) == eol);
+}
+
+function clearCounts(event) {
+    //if any button is pressed clear counts and remove keyup eventListner.
+    //except when Tab (play) button is pressed
+    if (event.keyCode !== 9) {
+        $(".characters-count").remove();
+        window.removeEventListener("keyup", clearCounts);
+    }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
 
   "name": "sonix.ai assistant",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "homepage_url": "https://github.com/IbraheemTuffaha/sonix-ai",
   "description": "An extension for sonix.ai to add more options related to fonts and managing characters in edit environment.",
   "permissions": [],


### PR DESCRIPTION
The following changes are made to reduce CPU load (some users experienced):

- ```AddCounts``` function is called once when the video starts playing. So a user has to press play (or <kbd>TAB</kbd>) to see the count.

- Pressing any other key will cause the counts to be cleared. I thought this is needed so users do not use old counts if they forgot to update (by pressing  <kbd>TAB</kbd> / play).
