### PR TITLE
fix caption div section dir attribute to depend on the language in use

### DIFF
--- a/js/add_caption.js
+++ b/js/add_caption.js
@@ -15,7 +15,6 @@ var element = document.getElementById("vjs_video_3");
 //this div will hold the captions
 var caption_container = document.createElement("div");
 caption_container.setAttribute("id", "caption_container");
-caption_container.setAttribute("dir", "rtl");
 caption_container.className = "caption-container";
 element.appendChild(caption_container);
 var caption = document.createElement("p");
@@ -25,8 +24,22 @@ var text = document.createTextNode("");
 caption.appendChild(text);
 caption_container.appendChild(caption);
 
+bFirstCaptionUpdate = true;
 
 function update_caption() {
+
+    if (bFirstCaptionUpdate) {
+        const rtlLangRegex = RegExp(/(Arabic|Hebrew)/);
+        const langDiv = document.getElementsByClassName("language--dropdown");
+        const lang = $(langDiv).text();
+        if (rtlLangRegex.test(lang)) {
+            caption_container.setAttribute("dir", "rtl");
+        } else {
+            caption_container.setAttribute("dir", "ltr");
+        }
+        bFirstCaptionUpdate = false;
+    }
+
     var current_time = vid.currentTime*100.0 + margin;//total_time * elabsed_bar_width;
     var paragraphs = getParagraphs();
     var index = get_index_of_paragraph(paragraphs, current_time);

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
 
   "name": "sonix.ai assistant",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "homepage_url": "https://github.com/IbraheemTuffaha/sonix-ai",
   "description": "An extension for sonix.ai to add more options related to fonts and managing characters in edit environment.",
   "permissions": [],


### PR DESCRIPTION
I worked on Dr. Eyad's latest video about Corona.

I noticed the captions are always set to `dir=rtl` irrespective of the language in use.

I submitted a fix for this small issue.

Please review.
@hasauino @AliOsm @IbraheemTuffaha 